### PR TITLE
Correct .png naming for Electron

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function createPNGs(position) {
 }
 
 function createPNG(size, callback) {
-    var fileName = size.toString() + '.png';
+    var fileName = size.toString() + 'x' + size.toString() + '.png';
 
     // make dir if does not exist
     if (!fs.existsSync(output)) {


### PR DESCRIPTION
The .png file names were not as per the Electron docs so changed them to be 'YYxYY.png'

This also added a missing '64x64' size icon to the .icns file :)