### PR TITLE
Fix issue where icon-gen 1.0.8 breaks the script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/jaretburkett/electron-icon-maker",
   "dependencies": {
     "args": "^2.3.0",
-    "icon-gen": "^1.0.7",
+    "icon-gen": "1.0.7",
     "jimp": "^0.2.27"
   }
 }


### PR DESCRIPTION
#3 #4 

Lock icon-gen version 1.0.7 until an update is made to support 1.0.8+